### PR TITLE
10 記事投稿に画像追加機能, 本番環境用の外部ストレージS3設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,3 +81,6 @@ gem "ruby-vips", "~> 2.2"
 
 # バリデーションをシンプルに書けるように設定
 gem "active_storage_validations", "~> 1.2"
+
+#  Active Storage の S3 サービスを利用
+gem "aws-sdk-s3", "~> 1.149"

--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,13 @@ gem "bootstrap", "~> 5.3.0"
 gem "sassc-rails"
 
 gem 'devise'
+
+# 画像変換用（Active Storageのvariantで必須）.
+gem "image_processing", "~> 1.12"
+gem "ruby-vips", "~> 2.2"
+
+# ※ MiniMagickに切り替えないため、mini_magickは削除
+# gem "mini_magick"
+
+# バリデーションをシンプルに書けるように設定
+gem "active_storage_validations", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,12 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_storage_validations (1.4.0)
+      activejob (>= 6.1.4)
+      activemodel (>= 6.1.4)
+      activestorage (>= 6.1.4)
+      activesupport (>= 6.1.4)
+      marcel (>= 1.0.3)
     activejob (7.1.5.1)
       activesupport (= 7.1.5.1)
       globalid (>= 0.3.6)
@@ -130,6 +136,9 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    image_processing (1.14.0)
+      mini_magick (>= 4.9.5, < 6)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.1.0)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -153,6 +162,8 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (5.3.0)
+      logger
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.8.0)
@@ -243,6 +254,9 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.4.1)
+    ruby-vips (2.2.4)
+      ffi (~> 1.12)
+      logger
     rubyzip (2.4.1)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -306,16 +320,19 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  active_storage_validations (~> 1.2)
   bootsnap
   bootstrap (~> 5.3.0)
   capybara
   debug
   devise
+  image_processing (~> 1.12)
   importmap-rails
   jbuilder
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.5, >= 7.1.5.1)
+  ruby-vips (~> 2.2)
   sassc-rails
   selenium-webdriver
   sprockets-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,25 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1147.0)
+    aws-sdk-core (3.229.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.110.0)
+      aws-sdk-core (~> 3, >= 3.228.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.196.1)
+      aws-sdk-core (~> 3, >= 3.228.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -151,6 +170,7 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     logger (1.6.6)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -321,6 +341,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_storage_validations (~> 1.2)
+  aws-sdk-s3 (~> 1.149)
   bootsnap
   bootstrap (~> 5.3.0)
   capybara

--- a/app/controllers/incense_reviews_controller.rb
+++ b/app/controllers/incense_reviews_controller.rb
@@ -46,6 +46,10 @@ class IncenseReviewsController < ApplicationController
   end
 
   def incense_review_params
-    params.require(:incense_review).permit(:title, :scent_category, :smoke_intensity, :content, :product_url, :product_name, :product_image)
+    params.require(:incense_review).permit(
+      :title, :scent_category, :smoke_intensity, :content,
+      :product_url, :product_name, :product_image,
+      :photo
+    )
   end
 end

--- a/app/models/incense_review.rb
+++ b/app/models/incense_review.rb
@@ -4,9 +4,15 @@ class IncenseReview < ApplicationRecord
 
   enum scent_category: { sweet: 0, woody: 1, floral: 2 }
 
+  has_one_attached :photo
+
   validates :title, presence: true
   validates :scent_category, presence: true
   validates :smoke_intensity, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }
   validates :content, presence: true
-end
 
+  # gem active_storage_validationsによる添付画像のバリデーション設定
+  validates :photo,
+  content_type: %w[image/png image/jpg image/jpeg image/webp],
+  size: { less_than: 10.megabytes }
+end

--- a/app/views/incense_reviews/edit.html.erb
+++ b/app/views/incense_reviews/edit.html.erb
@@ -26,6 +26,14 @@
     <%= form.text_field :product_url, class: "form-control" %>
   </div>
 
+  <div class="mb-3">
+    <%= f.label :photo, "商品画像（任意）", class: "form-label" %>
+    <%= f.file_field :photo,
+          accept: "image/png,image/jpeg,image/webp",
+          class: "form-control" %>
+    <div class="form-text">10MBまで。JPG/PNG/WEBP に対応</div>
+  </div>
+
   <%= form.submit "更新する", class: "btn btn-primary" %>
 <% end %>
 

--- a/app/views/incense_reviews/index.html.erb
+++ b/app/views/incense_reviews/index.html.erb
@@ -8,6 +8,17 @@
 
 <% @incense_reviews.each do |review| %>
   <div class="card mb-3">
+    <%# 画像（添付が優先。なければ既存の外部URL） %>
+    <% if review.photo.attached? %>
+      <%= image_tag review.photo.variant(resize_to_limit: [400, 400]).processed,
+            class: "card-img-top",
+            alt: "#{review.title} の画像" %>
+    <% elsif review.product_image.present? %>
+      <%= image_tag review.product_image,
+            class: "card-img-top",
+            alt: "#{review.title} の画像" %>
+    <% end %>
+
     <div class="card-body">
       <h5 class="card-title"><%= link_to review.title, review %></h5>
       <p class="card-text"><strong>香りのカテゴリ:</strong> <%= review.scent_category.humanize %></p>

--- a/app/views/incense_reviews/new.html.erb
+++ b/app/views/incense_reviews/new.html.erb
@@ -20,6 +20,14 @@
     <%= f.text_area :content %>
   </div>
 
+  <div class="mb-3">
+    <%= f.label :photo, "商品画像（任意）", class: "form-label" %>
+    <%= f.file_field :photo,
+          accept: "image/png,image/jpeg,image/webp",
+          class: "form-control" %>
+    <div class="form-text">画像は10MBまでで、JPG/PNG/WEBP に対応しています。</div>
+  </div>
+
   <div>
     <%= f.label :product_url, "製品ページURL" %>
     <%= f.text_field :product_url %>

--- a/app/views/incense_reviews/show.html.erb
+++ b/app/views/incense_reviews/show.html.erb
@@ -21,6 +21,14 @@
   </div>
 <% end %>
 
+<% if @incense_review.photo.attached? %>
+  <%= image_tag @incense_review.photo.variant(resize_to_limit: [1200, 1200]).processed,
+      class: "img-fluid rounded mb-3" %>
+<% elsif @incense_review.product_image.present? %>
+  <%= image_tag @incense_review.product_image, class: "img-fluid rounded mb-3" %>
+<% end %>
+
+
 <% if current_user == @incense_review.user %>
   <div class="my-3">
     <%= link_to "編集", edit_incense_review_path(@incense_review), class: "btn btn-primary" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,8 @@ module IncenseApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Active Storageを全環境でVipsに設定
+    config.active_storage.variant_processor = :vips
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,9 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
+  config.active_storage.variant_processor = :vips
+
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,13 +6,13 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+amazon:
+  service: S3
+  access_key_id:     <%= ENV["AWS_ACCESS_KEY_ID"]     || Rails.application.credentials.dig(:aws, :access_key_id) %>
+  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] || Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  region:            <%= ENV["AWS_REGION"]            || Rails.application.credentials.dig(:aws, :region) %>
+  bucket:            <%= ENV["AWS_BUCKET"]            || Rails.application.credentials.dig(:aws, :bucket) %>
+
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/db/migrate/20250815083932_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250815083932_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_14_105256) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_15_083932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "comments", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -57,8 +85,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_14_105256) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "incense_reviews"
   add_foreign_key "comments", "users"
   add_foreign_key "incense_reviews", "users"
 end
-


### PR DESCRIPTION
## 概要
画像投稿機能の追加と画像保存用の外部ストレージS3を設定

## 内容
- 記事投稿に画像追加機能を実装
※ 画像のリサイズはレスポンシブ対応時に修正する
- 画像保存の外部ストレージ (AWS S3)の設定を完了
→ 動作確認はmainへマージ後、Herokuで動作確認予定

Issuesとリンク
Closes #9 & #28
