### PR TITLE
11 レスポンシブ対応(Heroku+S3)の基礎を実装

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,2 @@
+libvips42
+libvips-dev

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "sassc-rails"
 
 gem 'devise'
 
-# 画像変換用（Active Storageのvariantで必須）.
+# 画像変換用（Active Storageのvariantで必須）.vipsを用いてレスポンシブ対応
 gem "image_processing", "~> 1.12"
 gem "ruby-vips", "~> 2.2"
 

--- a/app/helpers/responsive_image_helper.rb
+++ b/app/helpers/responsive_image_helper.rb
@@ -1,0 +1,64 @@
+module ResponsiveImageHelper
+    # record_or_attachment: モデル(@incense_review) か ActiveStorageのattachment(@incense_review.photo)
+    # attachment_name: モデルを渡した時の添付名
+    def responsive_image(record_or_attachment,
+                         alt: "",
+                         attachment_name: :photo,
+                         fallback_url: nil,
+                         widths: [320, 640, 960, 1280],
+                         sizes: "100vw",
+                         class_name: "img-fluid",
+                         format: :webp,
+                         quality: 70,
+                         loading: "lazy",
+                         decoding: "async",
+                         **attrs)
+  
+      attachment =
+        if record_or_attachment.respond_to?(attachment_name)
+          record_or_attachment.public_send(attachment_name)
+        else
+          record_or_attachment
+        end
+  
+      if attachment.respond_to?(:attached?) && attachment.attached?
+        # vips 用：saver: {quality: ...} を使う
+        make_variant = ->(w) {
+          attachment.variant(
+            resize_to_limit: [w, w],
+            format: format,
+            saver: { quality: quality, strip: true } # メタデータ削除で軽量化
+          )
+        }
+  
+        srcset_entries = widths.map { |w| "#{url_for(make_variant.call(w))} #{w}w" }
+        default_w = widths[widths.length / 2]
+  
+        image_tag(
+          url_for(make_variant.call(default_w)),
+          {
+            alt: alt,
+            srcset: srcset_entries.join(", "),
+            sizes: sizes,
+            loading: loading,
+            decoding: decoding,
+            class: class_name
+          }.merge(attrs)
+        )
+      elsif fallback_url.present?
+        image_tag(
+          fallback_url,
+          {
+            alt: alt,
+            loading: loading,
+            decoding: decoding,
+            class: class_name
+          }.merge(attrs)
+        )
+      else
+        # 画像が無いときのプレースホルダ（アスペクト比は親で確保）
+        content_tag(:div, "", class: "bg-light border rounded #{class_name}")
+      end
+    end
+  end
+  

--- a/app/views/incense_reviews/edit.html.erb
+++ b/app/views/incense_reviews/edit.html.erb
@@ -27,8 +27,8 @@
   </div>
 
   <div class="mb-3">
-    <%= f.label :photo, "商品画像（任意）", class: "form-label" %>
-    <%= f.file_field :photo,
+    <%= form.label :photo, "商品画像（任意）", class: "form-label" %>
+    <%= form.file_field :photo,
           accept: "image/png,image/jpeg,image/webp",
           class: "form-control" %>
     <div class="form-text">10MBまで。JPG/PNG/WEBP に対応</div>

--- a/app/views/incense_reviews/index.html.erb
+++ b/app/views/incense_reviews/index.html.erb
@@ -10,13 +10,21 @@
   <div class="card mb-3">
     <%# 画像（添付が優先。なければ既存の外部URL） %>
     <% if review.photo.attached? %>
-      <%= image_tag review.photo.variant(resize_to_limit: [400, 400]).processed,
-            class: "card-img-top",
-            alt: "#{review.title} の画像" %>
+      <%= image_tag review.photo.variant(
+            format: :webp,
+            resize_to_limit: [400, 400],
+            saver: { quality: 70, strip: true } # vips用
+          ).processed,
+          class: "card-img-top",
+          alt: "#{review.title} の画像",
+          loading: "lazy",
+          decoding: "async" %>
     <% elsif review.product_image.present? %>
       <%= image_tag review.product_image,
             class: "card-img-top",
-            alt: "#{review.title} の画像" %>
+            alt: "#{review.title} の画像",
+            loading: "lazy",
+            decoding: "async" %>
     <% end %>
 
     <div class="card-body">

--- a/app/views/incense_reviews/index.html.erb
+++ b/app/views/incense_reviews/index.html.erb
@@ -1,5 +1,7 @@
 <h2>レビュー一覧</h2>
 
+<h2>レビュー一覧</h2>
+
 <% if user_signed_in? %>
   <div class="mb-3">
     <%= link_to "レビューを投稿する", new_incense_review_path, class: "btn btn-outline-primary" %>
@@ -8,24 +10,19 @@
 
 <% @incense_reviews.each do |review| %>
   <div class="card mb-3">
-    <%# 画像（添付が優先。なければ既存の外部URL） %>
-    <% if review.photo.attached? %>
-      <%= image_tag review.photo.variant(
-            format: :webp,
-            resize_to_limit: [400, 400],
-            saver: { quality: 70, strip: true } # vips用
-          ).processed,
-          class: "card-img-top",
-          alt: "#{review.title} の画像",
-          loading: "lazy",
-          decoding: "async" %>
-    <% elsif review.product_image.present? %>
-      <%= image_tag review.product_image,
-            class: "card-img-top",
+
+    <%# 画像エリア: CLS対策としてアスペクト比を先に確保（4:3）。中の画像は responsive_image ヘルパでレスポンシブ配信 %>
+    <div class="ratio ratio-4x3 card-img-top overflow-hidden">
+      <%= responsive_image(
+            review,
             alt: "#{review.title} の画像",
-            loading: "lazy",
-            decoding: "async" %>
-    <% end %>
+            attachment_name: :photo,                    # Active Storage 添付名
+            fallback_url: review.product_image,         # 画像が無い場合の外部URLフォールバック
+            widths: [320, 640, 960, 1280],              # 生成する派生サイズ
+            sizes: "100vw",                             # 現状は1カラム想定。後で複数カラム化するなら調整
+            class_name: "w-100 h-100 object-fit-cover"  # 枠いっぱいに表示
+          ) %>
+    </div>
 
     <div class="card-body">
       <h5 class="card-title"><%= link_to review.title, review %></h5>

--- a/app/views/incense_reviews/show.html.erb
+++ b/app/views/incense_reviews/show.html.erb
@@ -15,24 +15,18 @@
   <p><strong>製品ページ:</strong> <%= link_to "こちら", @incense_review.product_url, target: "_blank", rel: "noopener" %></p>
 <% end %>
 
-<%# 画像表示：添付があれば WebP 変換（Vips）を優先, なければ product_image を表示 %>
-<% if @incense_review.photo.attached? %>
-  <%= image_tag @incense_review.photo.variant(
-        format: :webp,
-        resize_to_limit: [960, 960],
-        saver: { quality: 80, strip: true }
-      ).processed,
-      class: "img-fluid rounded mb-3",
-      alt: "#{@incense_review.title} の画像",
-      loading: "lazy",
-      decoding: "async" %>
-<% elsif @incense_review.product_image.present? %>
-  <%= image_tag @incense_review.product_image,
-      class: "img-fluid rounded mb-3",
-      alt: "#{@incense_review.title} の画像",
-      loading: "lazy",
-      decoding: "async" %>
-<% end %>
+<%# 画像表示: CLS対策としてアスペクト比を先に確保。中の画像は responsive_image でレスポンシブ配信 %>
+<div class="ratio mb-3" style="--bs-aspect-ratio: 100%;">
+  <%= responsive_image(
+        @incense_review,
+        alt: "#{@incense_review.title} の画像",
+        attachment_name: :photo,                       # Active Storage 添付名
+        fallback_url: @incense_review.product_image,   # 添付が無い場合のフォールバックURL
+        widths: [640, 960, 1280, 1600],                # 詳細ページ向けの派生サイズ
+        sizes: "(min-width: 992px) 960px, 100vw",      # PCでは最大960px、それ未満は画面幅
+        class_name: "w-100 h-100 object-fit-contain rounded"
+      ) %>
+</div>
 
 <% if current_user == @incense_review.user %>
   <div class="my-3">

--- a/app/views/incense_reviews/show.html.erb
+++ b/app/views/incense_reviews/show.html.erb
@@ -12,22 +12,27 @@
 </dl>
 
 <% if @incense_review.product_url.present? %>
-  <p><strong>製品ページ:</strong> <%= link_to "こちら", @incense_review.product_url, target: "_blank" %></p>
+  <p><strong>製品ページ:</strong> <%= link_to "こちら", @incense_review.product_url, target: "_blank", rel: "noopener" %></p>
 <% end %>
 
-<% if @incense_review.product_image.present? %>
-  <div class="text-center">
-    <img src="<%= @incense_review.product_image %>" alt="Product Image" class="img-fluid">
-  </div>
-<% end %>
-
+<%# 画像表示：添付があれば WebP 変換（Vips）を優先, なければ product_image を表示 %>
 <% if @incense_review.photo.attached? %>
-  <%= image_tag @incense_review.photo.variant(resize_to_limit: [1200, 1200]).processed,
-      class: "img-fluid rounded mb-3" %>
+  <%= image_tag @incense_review.photo.variant(
+        format: :webp,
+        resize_to_limit: [960, 960],
+        saver: { quality: 80, strip: true }
+      ).processed,
+      class: "img-fluid rounded mb-3",
+      alt: "#{@incense_review.title} の画像",
+      loading: "lazy",
+      decoding: "async" %>
 <% elsif @incense_review.product_image.present? %>
-  <%= image_tag @incense_review.product_image, class: "img-fluid rounded mb-3" %>
+  <%= image_tag @incense_review.product_image,
+      class: "img-fluid rounded mb-3",
+      alt: "#{@incense_review.title} の画像",
+      loading: "lazy",
+      decoding: "async" %>
 <% end %>
-
 
 <% if current_user == @incense_review.user %>
   <div class="my-3">

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module IncenseApp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # Active Storageを全環境でVipsに設定
+    # Active Storageを全環境でVipsに統一して設定
     config.active_storage.variant_processor = :vips
   end
 end


### PR DESCRIPTION
## 概要
- 前のブランチでの画像表示をwebP優先に修正
- 投稿編集ボタンのエラー修正
- レスポンシブ対応のための設定を追加

## 内容
- app/views/incense_reviews/index.html.erb , app/views/incense_reviews/show.html.erbをwebP優先に変更
- app/views/incense_reviews/edit.html.erb からフォームビルダー変数部分を修正
- Gemfile に gem "image_processing", "~> 1.12" 追加
- app/helpers/responsive_image_helper.rb　作成, 編集
- Bootstrap 5.3 の .ratio を使ってCLS対策（アスペクト比を先取りしてレイアウト崩れを防ぐ）
→ app/views/incense_reviews/index.html.erb, app/views/incense_reviews/show.html.erb の該当部分を修正
- リポジトリ直下に Aptfile を作成
- Herokuにaptビルドパックを追加

## Issuesとリンク
Closes #44
Closes #47