### PR TITLE
17 利用規約, プライバシーポリシーの実装

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PagesController < ApplicationController
+  # ApplicationController 側で authenticate_user! を強制していても安全に無効化
+  skip_before_action :authenticate_user!, raise: false
+
+  def terms; end
+  def privacy; end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>IncenseApp</title>
+    <title><%= content_for?(:title) ? "#{yield(:title)} | " : "" %>IncenseApp</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -57,5 +57,22 @@
     <div class="container mt-4">
       <%= yield %>
     </div>
+
+    <footer class="border-top py-3 mt-5 small">
+      <div class="container d-flex flex-wrap gap-3 justify-content-between">
+        <div class="text-muted">&copy; <%= Time.current.year %> IncenseApp</div>
+        <nav class="ms-auto">
+          <ul class="list-inline mb-0">
+            <li class="list-inline-item">
+              <%= link_to t('views.pages.nav.terms', locale: :ja), terms_path, class: "link-secondary" %>
+            </li>
+            <li class="list-inline-item">|</li>
+            <li class="list-inline-item">
+              <%= link_to t('views.pages.nav.privacy', locale: :ja), privacy_path, class: "link-secondary" %>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
   </body>
 </html>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, t('views.pages.privacy.title', locale: :ja) %>
+
+<nav aria-label="breadcrumb" class="mb-3">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <%= link_to t('helpers.label.home', default: 'ホーム'), root_path %>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">
+      <%= t('views.pages.privacy.heading', locale: :ja) %>
+    </li>
+  </ol>
+</nav>
+
+<h1 class="h3 mb-3"><%= t('views.pages.privacy.heading', locale: :ja) %></h1>
+
+<p class="text-body lh-lg mb-4">
+  <%= t('views.pages.privacy.updated_at', locale: :ja, date: '2025-09-16') %>
+</p>
+
+<div class="text-body lh-lg">
+  <p>当サービスは、ユーザーの個人情報を適切に取り扱います。</p>
+  <p>（テンプレート）取得情報・利用目的・第三者提供・安全管理措置・お問い合わせ窓口等を記載します。</p>
+</div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, t('views.pages.terms.title', locale: :ja) %>
+
+<nav aria-label="breadcrumb" class="mb-3">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <%= link_to t('helpers.label.home', default: 'ホーム'), root_path %>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">
+      <%= t('views.pages.terms.heading', locale: :ja) %>
+    </li>
+  </ol>
+</nav>
+
+<h1 class="h3 mb-3"><%= t('views.pages.terms.heading', locale: :ja) %></h1>
+
+<p class="text-body lh-lg mb-4">
+  <%= t('views.pages.terms.updated_at', locale: :ja, date: '2025-09-16') %>
+</p>
+
+<div class="text-body lh-lg">
+  <p>本サービスのご利用にあたっては、本規約に同意のうえご利用ください。</p>
+  <p>（テンプレート）禁止事項・免責・準拠法等をここに記載します。長文でもBootstrapの段落で適切に折り返されます。</p>
+</div>

--- a/config/locales/views/pages.ja.yml
+++ b/config/locales/views/pages.ja.yml
@@ -1,0 +1,14 @@
+ja:
+  views:
+    pages:
+      terms:
+        title: 利用規約
+        heading: 利用規約
+        updated_at: "最終改定日: %{date}"
+      privacy:
+        title: プライバシーポリシー
+        heading: プライバシーポリシー
+        updated_at: "最終改定日: %{date}"
+      nav:
+        terms: 利用規約
+        privacy: プライバシーポリシー

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,4 +20,7 @@ Rails.application.routes.draw do
   if Rails.env.development? # rubocop:disable Style/IfUnlessModifier
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
+  # 利用規約,プライバシーポリシーのページ設定
+  get '/terms',   to: 'pages#terms',   as: :terms
+  get '/privacy', to: 'pages#privacy', as: :privacy
 end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Static pages', type: :system do
+  # rack_test: ステータスコード検証や current_path の挙動が安定
+  before { driven_by(:rack_test) }
+
+  it 'allows direct access to /terms and /privacy when logged out' do
+    visit terms_path
+    expect(page).to have_current_path(terms_path, ignore_query: true)
+
+    visit privacy_path
+    expect(page).to have_current_path(privacy_path, ignore_query: true)
+  end
+
+  it 'is reachable from footer nav' do
+    visit root_path
+
+    within('footer') do
+      find("a[href='#{terms_path}']").click
+    end
+    expect(page).to have_current_path(terms_path, ignore_query: true)
+
+    visit root_path
+    within('footer') do
+      find("a[href='#{privacy_path}']").click
+    end
+    expect(page).to have_current_path(privacy_path, ignore_query: true)
+  end
+end


### PR DESCRIPTION
## 概要
- 静的ページで利用規約とプライバシーポリシーをPagesContorollerで実装
- システムテスト追加

## 内容
- 利用規約termsとプライバシーポリシーprivacyのルーティング追加
- PagesController 作成 (applicationControllerのauthenticate_user! をskip_before_actionで無効化)
- それぞれのビュー作成
- i18n対応用config/locales/views/pages.ja.yml 作成
- app/views/layouts/application.html.erb のフッターに利用規約とプライバシーポリシーをナビ表示
- RSpec (spec/system/static_pages_spec.rb)作成
- ローカルテストの実施，CIチェック済み
- Herokuへデプロイ

# Issues とリンク
Closes #25 
Closes #45 
